### PR TITLE
Metadata for kan.so - repository

### DIFF
--- a/kanso.json
+++ b/kanso.json
@@ -1,0 +1,16 @@
+{
+    "name": "backbone-pouch",
+    "version": "1.0.1-kanso.1",
+    "description": "Backbone PouchDB Sync Adapter",
+    "categories": ["frameworks"],
+    "modules": [
+        "backbone-pouch.js"
+    ],
+    "url" : "https://github.com/jo/backbone-pouch",
+    "dependencies": {
+        "modules": null,
+        "backbone": null,
+        "underscore": null,
+	"pouch" : null
+    }
+}


### PR DESCRIPTION
Added kanso.json for direct publishing into [kanso](http://kan.so) repository with `kanso publish`.

see: http://kan.so/packages/details/backbone-pouch
