### PR TITLE
Allow db to be specified as a function

### DIFF
--- a/backbone-pouch.js
+++ b/backbone-pouch.js
@@ -107,9 +107,9 @@
             // TODO:
             // * implement for model
             // * allow overwriding of since.
-            options.db.info(function(err, info) {
+            _.result(options, 'db').info(function(err, info) {
               // get changes since info.update_seq
-              options.db.changes(_.extend({}, options.options.changes, {
+              _.result(options, 'db').changes(_.extend({}, options.options.changes, {
                 since: info.update_seq,
                 onChange: function(change) {
                   var todo = model.get(change.id);
@@ -138,19 +138,19 @@
         return options.success && options.success(response);
       }
 
-      model.trigger('request', model, options.db, options);
+      model.trigger('request', model, _.result(options, 'db'), options);
 
       if (method === 'read') {
         // get single model
         if (model.id) {
-          return options.db.get(model.id, options.options.get, callback);
+          return _.result(options, 'db').get(model.id, options.options.get, callback);
         }
         // query view or spatial index
         if (options.fetch === 'query' || options.fetch === 'spatial') {
           if (!options.options[options.fetch].fun) {
             throw new Error('A "' + options.fetch + '.fun" object must be specified');
           }
-          return options.db[options.fetch](
+          return _.result(options, 'db')[options.fetch](
             options.options[options.fetch].fun,
             options.options[options.fetch]
           ).then( function(resp) {
@@ -160,9 +160,9 @@
           });
         }
         // allDocs or spatial query
-        options.db[options.fetch](options.options[options.fetch], callback);
+        _.result(options, 'db')[options.fetch](options.options[options.fetch], callback);
       } else {
-        options.db[methodMap[method]](model.toJSON(), options.options[methodMap[method]], callback);
+        _.result(options, 'db')[methodMap[method]](model.toJSON(), options.options[methodMap[method]], callback);
       }
 
       return options;
@@ -178,19 +178,19 @@
 
     function getPouch(model) {
       if (model.pouch && model.pouch.db) {
-        return model.pouch.db;
+        return _.result(model.pouch, 'db');
       }
       if (model.collection && model.collection.pouch && model.collection.pouch.db) {
-        return model.collection.pouch.db;
+        return _.result(model.collection.pouch, 'db');
       }
 
       if (defaults.db) {
-        return defaults.db;
+        return _.result(defaults, 'db');
       }
 
       var options = model.sync();
       if (options.db) {
-        return options.db;
+        return _.result(options, 'db');
       }
 
       // TODO: ask sync adapter


### PR DESCRIPTION
This is a simple change to allow `db` to be specified as a function that returns a `PouchDB`, while still supporting `db` directly referring to a specific `PouchDB` instance, by using `_.result`.

My use case for this is that users can essentially have multiple projects within my app, where each project has its own PouchDB but all projects use the same Backbone models. Currently I have to go through my models and collections and re-override `sync`/`fetch`/etc with the correct `db` any time a user changes projects. With this change, I can specify `db` as a function that returns the "current" PouchDB.

All tests pass, but I'm not sure of the best way to add tests for these changes, short of running all the existing tests twice (once where `db` is a PouchDB and once where `db` is a function that returns a PouchDB). I'd be happy to add or modify tests if I could get a suggestion as to the best approach.