### PR TITLE
Avoid setting multiple onChange handlers on models

### DIFF
--- a/backbone-pouch.js
+++ b/backbone-pouch.js
@@ -103,7 +103,7 @@
           response = {};
         }
         if (method === 'read') {
-          if (options.listen) {
+          if (options.listen && (model instanceof Backbone.Collection)) {
             // TODO:
             // * implement for model
             // * allow overwriding of since.


### PR DESCRIPTION
See TODO comment: use option "listen" only for collections as long as this is not implemented for models
