### PR TITLE
Bump pouch version to 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "backbone": "^1.1.2",
-    "pouchdb": "^3.1.0",
+    "pouchdb": "^5.0.0",
     "underscore": "^1.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Proposing bumping the pouchdb version.  I recently upgraded my node version to 4.2.0 and needed to bump pouchdb to 5.0.0 in order to get this library to work in my browserify build.  I'm not sure how many people have a need for this but I'm proposing anyway.